### PR TITLE
feat: improve error handling

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -24,12 +24,12 @@ impl VersionConstraint {
 }
 
 impl FromStr for VersionConstraint {
-    type Err = Vec<VersionConstraintError>;
+    type Err = VersionConstraintError;
 
     fn from_str(constraint_str: &str) -> Result<Self, Self::Err> {
         // Check if the constraint is empty
         if constraint_str.is_empty() {
-            return Err(vec![VersionConstraintError::EmptyConstraint]);
+            return Err(VersionConstraintError::EmptyConstraint);
         }
 
         // Match the comparators

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ pub enum VlsError {
     #[error("Invalid constraint(s): {}", .0.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", "))]
     InvalidConstraintError(Vec<VersionConstraintError>),
 
-    /// The input contains duplicate constraint version, irrespective of their comparators.
+    /// The input contains duplicate constraint versions, irrespective of their comparators.
     #[error("Duplicate constraint(s): {}", .0.iter().map(|s| format!("'{}'", s)).collect::<Vec<_>>().join(", "))]
     DuplicateConstraintVersions(BTreeSet<String>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for the `vls` crate.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use thiserror::Error;
 
 /// Errors specific to a single constraint within a VLS string.
@@ -47,5 +47,5 @@ pub enum VlsError {
 
     /// The input contains duplicate constraint version, irrespective of their comparators.
     #[error("Duplicate constraint(s): {}", .0.iter().map(|s| format!("'{}'", s)).collect::<Vec<_>>().join(", "))]
-    DuplicateConstraintVersions(HashSet<String>),
+    DuplicateConstraintVersions(BTreeSet<String>),
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -18,18 +18,18 @@ impl VersionString {
 }
 
 impl FromStr for VersionString {
-    type Err = Vec<VersionConstraintError>;
+    type Err = VersionConstraintError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         if input.is_empty() {
-            return Err(vec![VersionConstraintError::EmptyVersion]);
+            return Err(VersionConstraintError::EmptyVersion);
         }
 
         let invalid_chars = collect_invalid_characters(input, VlsSpecialCharSet::VersionString);
         if let Some(invalid_chars) = invalid_chars {
-            return Err(vec![VersionConstraintError::InvalidVersionCharacters(
+            return Err(VersionConstraintError::InvalidVersionCharacters(
                 invalid_chars,
-            )]);
+            ));
         }
 
         Ok(Self(input.to_string()))

--- a/src/vls.rs
+++ b/src/vls.rs
@@ -5,6 +5,7 @@ use crate::comparator::Comparator;
 use crate::constraint::VersionConstraint;
 use crate::error::{VersionConstraintError, VlsError};
 use crate::valid_chars::{VlsSpecialCharSet, collect_invalid_characters};
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Display;
@@ -137,7 +138,7 @@ impl FromStr for Vls {
         for part in parts {
             match part.parse::<VersionConstraint>() {
                 Ok(constraint) => constraints.push(constraint),
-                Err(errors) => constraint_errors.get_or_insert_default().extend(errors),
+                Err(error) => constraint_errors.get_or_insert_default().push(error),
             }
         }
 
@@ -148,7 +149,7 @@ impl FromStr for Vls {
 
         // Check for duplicate constraints
         let mut seen_versions: HashSet<&VersionString> = HashSet::new();
-        let mut duplicate_versions: Option<HashSet<String>> = None;
+        let mut duplicate_versions: Option<BTreeSet<String>> = None;
         for c in &constraints {
             if !seen_versions.insert(c.version()) {
                 duplicate_versions

--- a/tests/parsing_invalid.rs
+++ b/tests/parsing_invalid.rs
@@ -1,5 +1,5 @@
 use rstest::rstest;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use vls::{VersionConstraintError, Vls, VlsError};
 
 #[test]
@@ -132,7 +132,7 @@ fn parse_duplicate_constraints_is_error(#[case] input: &str, #[case] expected: V
     let err = input.parse::<Vls>().unwrap_err();
     assert!(matches!(err, VlsError::DuplicateConstraintVersions(_)));
     if let VlsError::DuplicateConstraintVersions(dupes) = err {
-        let expected: HashSet<String> = expected.into_iter().map(String::from).collect();
+        let expected: BTreeSet<String> = expected.into_iter().map(String::from).collect();
         assert_eq!(dupes, expected);
     }
 }


### PR DESCRIPTION
The duplicate version error is now based on a `BTreeSet` instead of a `HashSet`, which guarantees a deterministic order of the offending versions in the error message.

Also, the VersionConstraintError creation was simplified.

