### PR TITLE
feat: `*` / any / wildcard are forbidden in vls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust library for parsing and validating **Vers-like Specifiers** (vls) as defi
 
 vls is the `<version-constraint>` portion of a [vers](https://github.com/package-url/vers-spec) URL **without** the `vers:<scheme>/` prefix.
 
-It represents either a wildcard (`*`) matching any version, or a `|`-separated list of version constraints each consisting of an implicit or explicit comparator and a version string.
+It represents a `|`-separated list of version constraints each consisting of an implicit or explicit comparator and a version string.
 
 **Due to the undefined / unknown schema, it is nearly impossible for tools to reliably determine whether a given version is in the range or not. vls is a fallback option and SHOULD NOT be used unless really necessary.**
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! | Type | Description |
 //! |------|-------------|
-//! | [`Vls`] | Either at least one [`VersionConstraint`] or a single wildcard |
+//! | [`Vls`] | At least one [`VersionConstraint`] |
 //! | [`VersionConstraint`] | A [`Comparator`] / [`VersionString`] pair |
 //! | [`Comparator`] | A comparator used by [`VersionConstraint`] |
 //! | [`VersionString`] | A validated version string, used by [`VersionConstraint`] |

--- a/src/vls.rs
+++ b/src/vls.rs
@@ -89,7 +89,7 @@ impl FromStr for Vls {
 
         // If the string is a single wildcard, return an error
         if s == "*" {
-            return Err(VlsError::IsAny);
+            return Err(VlsError::ForbiddenAnyUsed);
         }
 
         // The next two checks are not strictly necessary, as we would try to parse
@@ -174,7 +174,7 @@ pub enum VlsError {
 
     /// The input is a wildcard (`*`), which is not allowed.
     #[error("'*' (vers syntax for matching all versions) is not allowed as a vls string")]
-    IsAny,
+    ForbiddenAnyUsed,
 
     /// The input contains characters not allowed by the VLS grammar.
     /// See [`Vls`] for more details on the grammar.

--- a/src/vls.rs
+++ b/src/vls.rs
@@ -12,25 +12,29 @@ use thiserror::Error;
 /// VLS is the `<version-constraint>` part of a [vers](https://github.com/package-url/vers-spec)
 /// URL *without* the `vers:<scheme>/` prefix.
 ///
-/// It is either an ordered, `|`-separated list of [`VersionConstraint`] values (via [Constraints](Self::Constraints))
-/// or a wildcard (`*`) indicating that any version is acceptable (via [Any](Self::Any)).
+/// It is an ordered, `|`-separated list of [`VersionConstraint`] values.
 ///
-/// Due to the unspecified format of the versions, only exact matching is possible and containment checks are not supported.
+/// Due to the unspecified format of the versions, only exact matching is possible and range containment checks are not supported.
 ///
 /// Be aware that when parsing of a string into [`Vls`], the parser returns the first [`VlsError`] encountered in the parsing process.
 /// This will obfuscate other errors that might appear further into the parsing process.
 ///
 /// # Syntax
 ///
-/// Derived from the [vers specification](https://www.packageurl.org/docs/vers/how-to-parse).
+/// Derived from the [vers specification](https://www.packageurl.org/docs/vers/how-to-parse) and
+/// its comments in
+/// [CSAF 2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#31232-branches-type---name-under-product-version-range)
+/// and
+/// [CSAF 2.1](https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html#branches-type---name-under-product-version-range).
+///
 /// There currently is no "official" grammar for vers-like specifier / the `<version-constraint>` part of
 /// vers. This is a best-effort attempt used for this library.
 ///
-/// **Note:** This grammar may need to be updated once vers has been ratified through ECMA.
+/// **Note:** This grammar may need to be updated once vers has been ratified through ECMA / following changes
+/// to / clarifications of CSAF 2.0 or CSAF 2.1.
 ///
 /// ```text
-/// vls            = constraints / "*"
-/// constraints    = constraint *( "|" constraint )
+/// vls            = constraint *( "|" constraint )
 /// constraint     = comparator version-string / version-string
 /// comparator     = "!=" / "<=" / ">=" / "=" / "<" / ">"
 /// version-string = 1*( ALPHA / DIGIT / "-" / "." / "_" / "+" / "~" )
@@ -55,35 +59,21 @@ use thiserror::Error;
 /// assert_eq!(vls.to_string(), ">10.9a|!=10.9c|!=10.9f|<=10.9k");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Vls {
-    /// Matches any version (`*`).
-    Any,
+pub struct Vls {
     /// An ordered, `|`-separated list of [`VersionConstraint`] values (always non-empty).
-    Constraints(Vec<VersionConstraint>),
+    constraints: Vec<VersionConstraint>,
 }
 
 impl Vls {
-    /// Return the constraints, or an empty slice for [`Any`](Self::Any).
+    /// Return the constraints.
     pub fn constraints(&self) -> &[VersionConstraint] {
-        match self {
-            Self::Any => &[],
-            Self::Constraints(cs) => cs,
-        }
-    }
-
-    /// Return `true` if this was parsed from a single `*`.
-    pub fn is_any(&self) -> bool {
-        matches!(self, Self::Any)
+        &self.constraints
     }
 
     /// Return `true` if this specifier pins exactly one version,
     /// i.e. it contains a single equal constraint [`EqualImplicit`](crate::comparator::Comparator::EqualImplicit) or [`EqualExplicit`](crate::comparator::Comparator::EqualExplicit)
     pub fn is_single_version(&self) -> bool {
-        matches!(
-            self,
-            Self::Constraints(cs)
-                if cs.len() == 1 && cs[0].comparator().is_equal()
-        )
+        self.constraints.len() == 1 && self.constraints[0].comparator().is_equal()
     }
 }
 
@@ -97,9 +87,9 @@ impl FromStr for Vls {
             return Err(VlsError::EmptyInput);
         }
 
-        // Early return for Any
+        // If the string is a single wildcard, return an error
         if s == "*" {
-            return Ok(Self::Any);
+            return Err(VlsError::IsAny);
         }
 
         // The next two checks are not strictly necessary, as we would try to parse
@@ -157,26 +147,21 @@ impl FromStr for Vls {
             return Err(VlsError::DuplicateConstraintVersions(duplicate_versions));
         }
 
-        Ok(Self::Constraints(constraints))
+        Ok(Self { constraints })
     }
 }
 
 impl Display for Vls {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Any => f.write_str("*"),
-            Self::Constraints(constraints) => {
-                let mut iter = constraints.iter();
-                if let Some(first) = iter.next() {
-                    first.fmt(f)?;
-                    for c in iter {
-                        f.write_str("|")?;
-                        c.fmt(f)?;
-                    }
-                }
-                Ok(())
+        let mut iter = self.constraints.iter();
+        if let Some(first) = iter.next() {
+            first.fmt(f)?;
+            for c in iter {
+                f.write_str("|")?;
+                c.fmt(f)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -186,6 +171,10 @@ pub enum VlsError {
     /// The input string was empty.
     #[error("Empty vls input")]
     EmptyInput,
+
+    /// The input is a wildcard (`*`), which is not allowed.
+    #[error("'*' (vers syntax for matching all versions) is not allowed as a vls string")]
+    IsAny,
 
     /// The input contains characters not allowed by the VLS grammar.
     /// See [`Vls`] for more details on the grammar.

--- a/tests/parsing_invalid.rs
+++ b/tests/parsing_invalid.rs
@@ -11,7 +11,7 @@ fn parse_empty_string_is_error() {
 #[test]
 fn parse_wildcard_is_error() {
     let err = "*".parse::<Vls>().unwrap_err();
-    assert!(matches!(err, VlsError::IsAny));
+    assert!(matches!(err, VlsError::ForbiddenAnyUsed));
 }
 
 #[rstest]

--- a/tests/parsing_invalid.rs
+++ b/tests/parsing_invalid.rs
@@ -8,6 +8,12 @@ fn parse_empty_string_is_error() {
     assert!(matches!(err, VlsError::EmptyInput));
 }
 
+#[test]
+fn parse_wildcard_is_error() {
+    let err = "*".parse::<Vls>().unwrap_err();
+    assert!(matches!(err, VlsError::IsAny));
+}
+
 #[rstest]
 #[case::vers("vers:gem/>=2.2.0")]
 #[case::vers_all("vers:all/*")]
@@ -38,8 +44,9 @@ fn parse_bare_scheme_is_error(#[case] input: &str) {
 #[case::space_and_comma(">=1,0 beta", vec![' ', ','])]
 #[case::hash_and_at("1.0#rc1@beta", vec!['#', '@'])]
 #[case::multiple_different("$1.0 @2.0#3", vec![' ', '#', '$', '@'])]
-#[case::star_in_version(">=1.0*", vec!['*'])]
-#[case::star_and_equals_equals_is_valid(">=1.0*=2", vec!['*'])]
+#[case::star_after_version_string(">=1.0*", vec!['*'])]
+#[case::star_before_version_string(">=*1.0", vec!['*'])]
+#[case::star_before_comparator("*>=1.0*", vec!['*'])]
 fn parse_invalid_constraints_chars_is_error(
     #[case] input: &str,
     #[case] expected_chars: Vec<char>,

--- a/tests/parsing_valid.rs
+++ b/tests/parsing_valid.rs
@@ -1,16 +1,6 @@
 use rstest::rstest;
 use vls::{Comparator, Vls};
 
-#[test]
-fn parse_single_any() {
-    let v: Vls = "*".parse().unwrap();
-    assert_eq!(v, Vls::Any);
-    assert!(v.is_any());
-    assert!(v.constraints().is_empty());
-    assert_eq!(v.to_string(), "*");
-    assert!(!v.is_single_version());
-}
-
 #[rstest]
 #[case("<=2", Comparator::LessThanOrEqual, "2", false)]
 #[case("<4.2", Comparator::LessThan, "4.2", false)]
@@ -28,7 +18,6 @@ fn parse_single_versioned_constraint(
     let v: Vls = input
         .parse()
         .expect("Expected valid vls constraints to parse");
-    assert!(matches!(v, Vls::Constraints(_)));
     assert_eq!(v.to_string(), input);
     let cs = v.constraints();
     assert_eq!(cs.len(), 1);
@@ -49,7 +38,6 @@ fn parse_multiple_constraints() {
     let v: Vls = input
         .parse()
         .expect("Expected valid vls constraints to parse");
-    assert!(matches!(v, Vls::Constraints(_)));
     assert!(!v.is_single_version());
 
     let cs = v.constraints();


### PR DESCRIPTION
Relates to #23 / https://github.com/oasis-tcs/csaf/issues/1445

As remarked / soon to be clarified upstream, `*` / any / wildcard representing any version in vers syntax is not allowed in vls.

This PR removes `*` as a passing parsing result and adds an error (`VlsError::IsAny`) for when a single `*` is encountered as input.

If `*`s are encountered as a substring, as before, an `VlsError::InvalidCharacters` error is returned. 

The relevant test cases are modified / added, and the README / vls.rs doc comment / vls grammar is updated.