### PR TITLE
refactor: apply vers-spec naming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Rust library for parsing and validating **Vers-like Specifiers** (vls) as defined in [CSAF 2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#31232-branches-type---name-under-product-version-range) and [CSAF 2.1](https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html#branches-type---name-under-product-version-range).
 
-vls is the `<version-constraint>` portion of a [vers](https://github.com/package-url/vers-spec) URL **without** the `vers:<scheme>/` prefix.
+vls is the `<constraints>` portion of a [vers](https://github.com/package-url/vers-spec) URL **without** the `vers:<type>/` prefix.
 
 It represents a `|`-separated list of version constraints each consisting of an implicit or explicit comparator and a version string.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust library for parsing and validating **Vers-like Specifiers** (vls) as defi
 
 vls is the `<constraints>` portion of a [vers](https://github.com/package-url/vers-spec) URL **without** the `vers:<type>/` prefix.
 
-It represents a `|`-separated list of version constraints each consisting of an implicit or explicit comparator and a version string.
+It represents a `|`-separated list of constraints each consisting of an implicit or explicit comparator and a version string.
 
 **Due to the undefined / unknown schema, it is nearly impossible for tools to reliably determine whether a given version is in the range or not. vls is a fallback option and SHOULD NOT be used unless really necessary.**
 

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -1,16 +1,16 @@
 //! Comparator type for the csaf-rs/vls library.
 //!
 //! The `Comparator` enum represents the different types of comparators that can be used
-//! in version constraints, such as = (implicit or explicit), !=, <, <=, >, and >=.
+//! in constraints, such as = (implicit or explicit), !=, <, <=, >, and >=.
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 use strum::AsRefStr;
 
-/// Comparator for version constraints.
+/// Comparator for constraints.
 ///
 /// This enum represents the different types of comparators that can be used
-/// in version constraints. Each comparator defines how a version is compared
+/// in constraints. Each comparator defines how a version is compared
 /// to the constraint version.
 ///
 /// # Equality

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -4,14 +4,14 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
 use thiserror::Error;
 
-/// A single version constraint pairing a [`Comparator`] with a validated [`VersionString`].
+/// A single constraint pairing a [`Comparator`] with a validated [`VersionString`].
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub struct VersionConstraint {
+pub struct Constraint {
     comparator: Comparator,
     version: VersionString,
 }
 
-impl VersionConstraint {
+impl Constraint {
     /// Returns the comparator of this constraint.
     pub fn comparator(&self) -> &Comparator {
         &self.comparator
@@ -23,13 +23,13 @@ impl VersionConstraint {
     }
 }
 
-impl FromStr for VersionConstraint {
-    type Err = VersionConstraintError;
+impl FromStr for Constraint {
+    type Err = ConstraintError;
 
     fn from_str(constraint_str: &str) -> Result<Self, Self::Err> {
         // Check if the constraint is empty
         if constraint_str.is_empty() {
-            return Err(VersionConstraintError::EmptyConstraint);
+            return Err(ConstraintError::EmptyConstraint);
         }
 
         // Match the comparators
@@ -38,14 +38,14 @@ impl FromStr for VersionConstraint {
         // Parse and validate the version string (checks empty + invalid chars)
         let version: VersionString = version_str.parse()?;
 
-        Ok(VersionConstraint {
+        Ok(Constraint {
             comparator,
             version,
         })
     }
 }
 
-impl Display for VersionConstraint {
+impl Display for Constraint {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}{}", self.comparator, self.version)
     }
@@ -53,17 +53,17 @@ impl Display for VersionConstraint {
 
 /// Errors specific to a single constraint within a VLS string.
 #[derive(Error, Debug, PartialEq, Eq)]
-pub enum VersionConstraintError {
+pub enum ConstraintError {
     /// A constraint segment was empty (e.g. from `||`, a leading `|`, or a trailing `|`).
     #[error("Empty constraint")]
     EmptyConstraint,
 
     /// The version part of a constraint was empty (e.g. `>=` without a version).
     #[error("Empty version in constraint")]
-    EmptyVersion,
+    EmptyConstraintVersion,
 
     /// The version string contains characters outside the allowed grammar.
     /// See [`Vls`](crate::Vls) for more details on the grammar.
     #[error("Invalid character(s) in version string: {}", .0.iter().map(|c| format!("'{}'", c.escape_default())).collect::<Vec<_>>().join(", "))]
-    InvalidVersionCharacters(Vec<char>),
+    InvalidConstraintVersionCharacters(Vec<char>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,24 @@
 //! # vls — vers-like specifier parser
 //!
-//! `vls` is a parser for **vers-like specifiers** (vls), the `<version-constraint>` part
+//! `vls` is a parser for **vers-like specifiers** (vls), the `<constraints>` part
 //! of a [vers](https://github.com/package-url/vers-spec) URL *without* the
-//! `vers:<scheme>/` prefix.
+//! `vers:<type>/` prefix.
 //!
 //! | Type | Description |
 //! |------|-------------|
-//! | [`Vls`] | At least one [`VersionConstraint`] |
-//! | [`VersionConstraint`] | A [`Comparator`] / [`VersionString`] pair |
-//! | [`Comparator`] | A comparator used by [`VersionConstraint`] |
-//! | [`VersionString`] | A validated version string, used by [`VersionConstraint`] |
+//! | [`Vls`] | At least one [`Constraint`] |
+//! | [`Constraint`] | A [`Comparator`] / [`VersionString`] pair |
+//! | [`Comparator`] | A comparator used by [`Constraint`] |
+//! | [`VersionString`] | A validated version string, used by [`Constraint`] |
 //!
 //! ## Error Types
 //!
 //! | Type | Description |
 //! |------|-------------|
 //! | [`VlsError`] | Returned when parsing a vls string fails |
-//! | [`VersionConstraintError`] | Returned when parsing a single [`VersionConstraint`] fails |
+//! | [`ConstraintError`] | Returned when parsing a single [`Constraint`] fails |
 
-pub use constraint::{Comparator, VersionConstraint, VersionConstraintError, VersionString};
+pub use constraint::{Comparator, Constraint, ConstraintError, VersionString};
 pub use vls::{Vls, VlsError};
 
 mod comparator;

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,4 @@
-use crate::VersionConstraintError;
+use crate::ConstraintError;
 use crate::valid_chars::{VlsSpecialCharSet, collect_invalid_characters};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
@@ -18,16 +18,16 @@ impl VersionString {
 }
 
 impl FromStr for VersionString {
-    type Err = VersionConstraintError;
+    type Err = ConstraintError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         if input.is_empty() {
-            return Err(VersionConstraintError::EmptyVersion);
+            return Err(ConstraintError::EmptyConstraintVersion);
         }
 
         let invalid_chars = collect_invalid_characters(input, VlsSpecialCharSet::VersionString);
         if let Some(invalid_chars) = invalid_chars {
-            return Err(VersionConstraintError::InvalidVersionCharacters(
+            return Err(ConstraintError::InvalidConstraintVersionCharacters(
                 invalid_chars,
             ));
         }

--- a/src/vls.rs
+++ b/src/vls.rs
@@ -190,7 +190,8 @@ pub enum VlsError {
     #[error("VLS must not contain a vers type component")]
     ContainsVersType,
 
-    /// One or more version strings contain characters outside the allowed grammar.
+    /// One or more constraints are invalid, for example due to constraints or version strings
+    /// being empty, or due to invalid characters in version strings.
     #[error("Invalid constraint(s): {}", .0.iter().map(std::string::ToString::to_string).collect::<Vec<_>>().join(", "))]
     InvalidConstraints(Vec<ConstraintError>),
 

--- a/src/vls.rs
+++ b/src/vls.rs
@@ -1,6 +1,6 @@
 //! The core [`Vls`] type.
 
-use crate::constraint::{VersionConstraint, VersionConstraintError, VersionString};
+use crate::constraint::{Constraint, ConstraintError, VersionString};
 use crate::valid_chars::{VlsSpecialCharSet, collect_invalid_characters};
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -9,10 +9,10 @@ use thiserror::Error;
 
 /// A **Vers-like Specifier** (VLS).
 ///
-/// VLS is the `<version-constraint>` part of a [vers](https://github.com/package-url/vers-spec)
-/// URL *without* the `vers:<scheme>/` prefix.
+/// VLS is the `<constraints>` part of a [vers](https://github.com/package-url/vers-spec)
+/// URL *without* the `vers:<type>/` prefix.
 ///
-/// It is an ordered, `|`-separated list of [`VersionConstraint`] values.
+/// It is an ordered, `|`-separated list of [`Constraint`] values.
 ///
 /// Due to the unspecified format of the versions, only exact matching is possible and range containment checks are not supported.
 ///
@@ -27,7 +27,7 @@ use thiserror::Error;
 /// and
 /// [CSAF 2.1](https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html#branches-type---name-under-product-version-range).
 ///
-/// There currently is no "official" grammar for vers-like specifier / the `<version-constraint>` part of
+/// There currently is no "official" grammar for vers-like specifier / the `<constraints>` part of
 /// vers. This is a best-effort attempt used for this library.
 ///
 /// **Note:** This grammar may need to be updated once vers has been ratified through ECMA / following changes
@@ -60,13 +60,13 @@ use thiserror::Error;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Vls {
-    /// An ordered, `|`-separated list of [`VersionConstraint`] values (always non-empty).
-    constraints: Vec<VersionConstraint>,
+    /// An ordered, `|`-separated list of [`Constraint`] values (always non-empty).
+    constraints: Vec<Constraint>,
 }
 
 impl Vls {
     /// Return the constraints.
-    pub fn constraints(&self) -> &[VersionConstraint] {
+    pub fn constraints(&self) -> &[Constraint] {
         &self.constraints
     }
 
@@ -93,7 +93,7 @@ impl FromStr for Vls {
         }
 
         // The next two checks are not strictly necessary, as we would try to parse
-        // a string containing the vers URI prefix and / or a scheme component as part of
+        // a string containing the vers URI prefix and / or a type component as part of
         // the first constraint, which would fail the parsing.
         // As this library is tightly coupled to csaf-rs, we still include them for easier /
         // more informative error handling there, as both indicate this might be a vers string.
@@ -103,10 +103,10 @@ impl FromStr for Vls {
             return Err(VlsError::ContainsVersPrefix);
         }
 
-        // `/` is not a valid character in the vls grammar, but is used as the scheme delimiter in vers.
-        // Its presence indicates the string contains a "<scheme>/" component
+        // `/` is not a valid character in the vls grammar, but is used as the type delimiter in vers.
+        // Its presence indicates the string contains a "<type>/" component
         if s.contains('/') {
-            return Err(VlsError::ContainsVersioningScheme);
+            return Err(VlsError::ContainsVersType);
         }
 
         // Reject any character that is not part of the 'constraints' grammar.
@@ -117,12 +117,12 @@ impl FromStr for Vls {
         // Split the constraints
         let parts: Vec<&str> = s.split('|').collect();
 
-        // Parse the constraints, generating parsed VersionConstraint or VersionConstraintErrors for each
-        let mut constraints: Vec<VersionConstraint> = Vec::with_capacity(parts.len());
-        let mut constraint_errors: Option<Vec<VersionConstraintError>> = None;
+        // Parse the constraints, generating parsed Constraint or ConstraintErrors for each
+        let mut constraints: Vec<Constraint> = Vec::with_capacity(parts.len());
+        let mut constraint_errors: Option<Vec<ConstraintError>> = None;
 
         for part in parts {
-            match part.parse::<VersionConstraint>() {
+            match part.parse::<Constraint>() {
                 Ok(constraint) => constraints.push(constraint),
                 Err(error) => constraint_errors.get_or_insert_default().push(error),
             }
@@ -185,14 +185,14 @@ pub enum VlsError {
     #[error("VLS must not contain a 'vers:' URI prefix")]
     ContainsVersPrefix,
 
-    /// The input most likely contains a `vers` versioning-scheme
-    /// component (e.g. `gem/>=2.2.0`), indicated by the presence of the scheme delimiter `/`.
-    #[error("VLS must not contain a versioning-scheme component")]
-    ContainsVersioningScheme,
+    /// The input most likely contains a vers type
+    /// component (e.g. `gem` in `gem/>=2.2.0`), indicated by the presence of the type delimiter `/`.
+    #[error("VLS must not contain a vers type component")]
+    ContainsVersType,
 
     /// One or more version strings contain characters outside the allowed grammar.
     #[error("Invalid constraint(s): {}", .0.iter().map(std::string::ToString::to_string).collect::<Vec<_>>().join(", "))]
-    InvalidConstraints(Vec<VersionConstraintError>),
+    InvalidConstraints(Vec<ConstraintError>),
 
     /// The input contains duplicate constraint versions, irrespective of their comparators.
     #[error("Duplicate constraint version(s): {}", .0.iter().map(|s| format!("'{s}'")).collect::<Vec<_>>().join(", "))]

--- a/tests/parsing_invalid.rs
+++ b/tests/parsing_invalid.rs
@@ -1,6 +1,6 @@
 use rstest::rstest;
 use std::collections::BTreeSet;
-use vls::{VersionConstraintError, Vls, VlsError};
+use vls::{ConstraintError, Vls, VlsError};
 
 #[test]
 fn parse_empty_string_is_error() {
@@ -27,7 +27,7 @@ fn parse_vers_prefix_is_error(#[case] input: &str) {
 #[case::only_scheme_delimiter("/>=2.2.0")]
 fn parse_bare_scheme_is_error(#[case] input: &str) {
     let err = input.parse::<Vls>().unwrap_err();
-    assert!(matches!(err, VlsError::ContainsVersioningScheme));
+    assert!(matches!(err, VlsError::ContainsVersType));
 }
 
 #[rstest]
@@ -74,7 +74,7 @@ fn parse_empty_constraint_is_error(#[case] input: &str, #[case] expected_count: 
         assert!(
             errors
                 .iter()
-                .all(|e| matches!(e, VersionConstraintError::EmptyConstraint))
+                .all(|e| matches!(e, ConstraintError::EmptyConstraint))
         );
     }
 }
@@ -98,7 +98,7 @@ fn parse_empty_version_is_error(#[case] input: &str, #[case] expected_count: usi
         assert!(
             errors
                 .iter()
-                .all(|e| matches!(e, VersionConstraintError::EmptyVersion))
+                .all(|e| matches!(e, ConstraintError::EmptyConstraintVersion))
         );
     }
 }
@@ -119,7 +119,7 @@ fn parse_invalid_version_characters_is_error(
         assert_eq!(errors.len(), expected_chars.len());
         for (i, error) in errors.iter().enumerate() {
             match error {
-                VersionConstraintError::InvalidVersionCharacters(chars) => {
+                ConstraintError::InvalidConstraintVersionCharacters(chars) => {
                     assert_eq!(chars, &expected_chars[i]);
                 }
                 other => panic!("Expected InvalidVersionCharacters, got: {other:?}"),

--- a/tests/parsing_invalid.rs
+++ b/tests/parsing_invalid.rs
@@ -23,9 +23,9 @@ fn parse_vers_prefix_is_error(#[case] input: &str) {
 }
 
 #[rstest]
-#[case::gem_scheme("gem/>=2.2.0")]
-#[case::only_scheme_delimiter("/>=2.2.0")]
-fn parse_bare_scheme_is_error(#[case] input: &str) {
+#[case::gem_type("gem/>=2.2.0")]
+#[case::only_type_delimiter("/>=2.2.0")]
+fn parse_contains_vers_type_is_error(#[case] input: &str) {
     let err = input.parse::<Vls>().unwrap_err();
     assert!(matches!(err, VlsError::ContainsVersType));
 }


### PR DESCRIPTION
Resolves #27 

Apply https://github.com/package-url/vers-spec/pull/67 to the repos code and docs.