### PR TITLE
Use shared composite actions for Rust CI format and lint checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run shared format check
         uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
         with:
-          run-format: "true"
+          run-clippy: "false"
       - name: Publish dry-run
         if: github.ref_type != 'tag'
         run: cargo publish --dry-run --verbose --no-verify --locked
@@ -64,8 +64,7 @@ jobs:
       - name: Run shared clippy check
         uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
         with:
-          run-clippy: "true"
-          clippy-args: "--all-targets --locked"
+          run-format: "false"
       - name: Build
         run: cargo build --locked --release --verbose
       - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
       - uses: actions/checkout@v7
       - name: Update rustup
         run: rustup update stable --no-self-update
-      - name: Format check
-        run: |
-          rustup component add rustfmt
-          cargo fmt --all -- --check -l
+      - name: Run shared format check
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
+        with:
+          run-format: "true"
       - name: Publish dry-run
         if: github.ref_type != 'tag'
         run: cargo publish --dry-run --verbose --no-verify --locked
@@ -61,10 +61,11 @@ jobs:
         run: |
           rustup override set "${{ steps.rust-version.outputs.version }}"
           rustup default "${{ steps.rust-version.outputs.version }}"
-      - name: Install clippy
-        run: rustup component add clippy
-      - name: Clippy check
-        run: cargo clippy --all-targets --locked -- -D warnings
+      - name: Run shared clippy check
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
+        with:
+          run-clippy: "true"
+          clippy-args: "--all-targets --locked"
       - name: Build
         run: cargo build --locked --release --verbose
       - name: Run tests


### PR DESCRIPTION
This PR addresses csaf-rs/csaf#787.

**Note:** Before merging this PR, please make sure that the dependent [shared-workflows PR](https://github.com/csaf-rs/shared-workflows/pull/1) has been merged first, since this workflow uses the composite action introduced there.

This PR updates the `vers-like-specifier` build workflow to use the shared `rust-checks` composite action from `csaf-rs/shared-workflows` for the existing formatting and Clippy checks.

The existing repository-specific checks and logic remain in `vers-like-specifier`. The existing Clippy arguments are preserved.

Implementation details and validation of the shared action can be found in the dependent [shared-workflows PR](https://github.com/csaf-rs/shared-workflows/pull/1).