### PR TITLE
Pin shared workflows to v1.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Update rustup
         run: rustup update stable --no-self-update
       - name: Run shared format check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@e9079b9470e42db0f885b53579456969d1a4914e # v1.0.0
         with:
           run-clippy: "false"
       - name: Publish dry-run
@@ -62,7 +62,7 @@ jobs:
           rustup override set "${{ steps.rust-version.outputs.version }}"
           rustup default "${{ steps.rust-version.outputs.version }}"
       - name: Run shared clippy check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@e9079b9470e42db0f885b53579456969d1a4914e # v1.0.0
         with:
           run-format: "false"
       - name: Build


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/shared-workflows/issues/7.

It pins the shared composite action calls to a specific commit SHA, with `v1.0.0` included as a version comment, instead of using main. This ensures that future changes to [shared-workflows](https://github.com/csaf-rs/shared-workflows) do not affect this repository until a new version is released and updated by Dependabot.