### PR TITLE
Use shared CI documentation check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Update rustup
         run: rustup update stable --no-self-update
-      - name: Run shared format check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@e9079b9470e42db0f885b53579456969d1a4914e # v1.0.0
+      - name: Run shared format and doc checks
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@8d7fd6241752c334d1c60e80a355722f44d9b99e # v1.2.0
         with:
           run-clippy: "false"
       - name: Publish dry-run
@@ -62,9 +62,10 @@ jobs:
           rustup override set "${{ steps.rust-version.outputs.version }}"
           rustup default "${{ steps.rust-version.outputs.version }}"
       - name: Run shared clippy check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@e9079b9470e42db0f885b53579456969d1a4914e # v1.0.0
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@8d7fd6241752c334d1c60e80a355722f44d9b99e # v1.2.0
         with:
           run-format: "false"
+          run-doc: "false"
       - name: Build
         run: cargo build --locked --release --verbose
       - name: Run tests


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/shared-workflows/issues/6

It updates the shared CI Rust checks to v1.2.0 and enables the centralized documentation check.