### PR TITLE
ci: use shared cargo publish dry-run action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           run-clippy: "false"
       - name: Publish dry-run
         if: github.ref_type != 'tag'
-        run: cargo publish --dry-run --verbose --no-verify --locked
+        uses: csaf-rs/shared-workflows/.github/actions/cargo-publish-dry-run@56bcf77399696052c9eb925a6059c77c1eaab1bc # v1.6.0
 
   build:
     needs: lint


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/shared-workflows/issues/17.

It replaces the local `Cargo publish dry-run` step with the shared cargo-publish-dry-run composite action from [shared-workflows](https://github.com/csaf-rs/shared-workflows).