### PR TITLE
ci: use shared Rust version detection action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,47 +22,44 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      msrv-version: ${{ steps.rust-versions.outputs.msrv-version }}
+      stable-version: ${{ steps.rust-versions.outputs.stable-version }}
     steps:
       - uses: actions/checkout@v7
       - name: Update rustup
         run: rustup update stable --no-self-update
+      - name: Extract Rust versions
+        id: rust-versions
+        uses: csaf-rs/shared-workflows/.github/actions/rust-versions@c140782d72e8124210e90c274101848ca0ba0e54 # v1.7.0
       - name: Run shared format and doc checks
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@8d7fd6241752c334d1c60e80a355722f44d9b99e # v1.2.0
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@c140782d72e8124210e90c274101848ca0ba0e54 # v1.7.0
         with:
           run-clippy: "false"
       - name: Publish dry-run
         if: github.ref_type != 'tag'
-        uses: csaf-rs/shared-workflows/.github/actions/cargo-publish-dry-run@56bcf77399696052c9eb925a6059c77c1eaab1bc # v1.6.0
+        uses: csaf-rs/shared-workflows/.github/actions/cargo-publish-dry-run@c140782d72e8124210e90c274101848ca0ba0e54 # v1.7.0
 
   build:
-    needs: lint
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       matrix:
         version:
-          - msrv
-          - stable
+          - ${{ needs.prepare.outputs.msrv-version }}
+          - ${{ needs.prepare.outputs.stable-version }}
     steps:
       - uses: actions/checkout@v7
       - name: Update rustup
         run: rustup update stable --no-self-update
-      - name: Determine Rust version
-        id: rust-version
-        run: |
-          if [[ "${{ matrix.version }}" == "msrv" ]]; then
-            VERSION=$(cargo metadata --no-deps --format-version=1 --locked | jq -r '.packages[0].rust_version')
-          else
-            VERSION=$(rustc +stable --version | awk '{print $2}')
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Set Rust version
         run: |
-          rustup override set "${{ steps.rust-version.outputs.version }}"
-          rustup default "${{ steps.rust-version.outputs.version }}"
+          rustup override set "${{ matrix.version }}"
+          rustup default "${{ matrix.version }}"
       - name: Run shared clippy check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@8d7fd6241752c334d1c60e80a355722f44d9b99e # v1.2.0
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@c140782d72e8124210e90c274101848ca0ba0e54 # v1.7.0
         with:
           run-format: "false"
           run-doc: "false"
@@ -72,4 +69,4 @@ jobs:
         run: cargo test --locked --release --verbose
 
   coverage:
-    uses: csaf-rs/shared-workflows/.github/workflows/rust-coverage.yml@400ee021e6bdeb7e2808264749e2fe20b25401e8 # v1.3.0
+    uses: csaf-rs/shared-workflows/.github/workflows/rust-coverage.yml@c140782d72e8124210e90c274101848ca0ba0e54 # v1.7.0


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/shared-workflows/issues/19.

It replaces the local MSRV and stable Rust version detection with the shared `rust-versions` composite action from https://github.com/csaf-rs/shared-workflows [v1.7.0](https://github.com/csaf-rs/shared-workflows/releases/tag/v1.7.0)