### PR TITLE
chore: group shared workflows Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      shared-workflows:
+        patterns:
+          - "csaf-rs/shared-workflows*"


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/shared-workflows/issues/25.

It configures Dependabot to group updates for `csaf-rs/shared-workflows` usages into a single PR instead of creating separate PRs for each shared composite action and reusable workflow.